### PR TITLE
Replace the DTO class in ingest call with a plain string

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java-library'
     id "io.freefair.lombok" version "${ioFreeFairLombok}"
     id 'maven-publish'
+	id "jacoco"
 }
 
 repositories {
@@ -48,6 +49,11 @@ dependencies {
     implementation group: 'jakarta.validation', name: 'jakarta.validation-api', version: '3.1.1'
 	// https://mvnrepository.com/artifact/jakarta.persistence/jakarta.persistence-api
 	implementation group: 'jakarta.persistence', name: 'jakarta.persistence-api', version: '3.1.0'
+	// https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
+	testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: '5.19.0'
+	// https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter
+	testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter', version: '5.13.4'
+	testRuntimeOnly group: 'org.junit.platform', name: 'junit-platform-launcher', version: '1.11.0'
 }
 
 // Publish the API module to GitHub Packages when invoked by CI
@@ -85,4 +91,23 @@ publishing {
             }
         }
     }
+}
+
+jacoco {
+	toolVersion = "0.8.13"
+}
+
+tasks.named('test') {
+	useJUnitPlatform()
+}
+
+test {
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+	dependsOn test
+	reports {
+		xml.required = true
+	}
 }

--- a/api/src/main/java/fi/poltsi/vempain/admin/VempainServiceApiDefinition.java
+++ b/api/src/main/java/fi/poltsi/vempain/admin/VempainServiceApiDefinition.java
@@ -5,8 +5,8 @@ import io.swagger.v3.oas.annotations.info.Info;
 import io.swagger.v3.oas.annotations.servers.Server;
 import lombok.experimental.UtilityClass;
 
-@OpenAPIDefinition(info = @Info(version = "${info.build.version}", title = "Vempain Service REST endpoints"),
-				   servers = @Server(url = "http://localhost:8080/api", description = "current server"))
+@OpenAPIDefinition(info = @Info(version = "${info.build.version}", title = "Vempain Admin Service REST endpoints"),
+				   servers = @Server(url = "http://localhost:${server.port}/api", description = "current server"))
 @UtilityClass
 public class VempainServiceApiDefinition {
 }

--- a/api/src/main/java/fi/poltsi/vempain/admin/rest/file/FileIngestAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/admin/rest/file/FileIngestAPI.java
@@ -1,12 +1,7 @@
 package fi.poltsi.vempain.admin.rest.file;
 
-import fi.poltsi.vempain.admin.api.request.file.FileIngestRequest;
 import fi.poltsi.vempain.admin.api.response.file.FileIngestResponse;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Encoding;
-import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
@@ -33,10 +28,6 @@ public interface FileIngestAPI {
 			consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
 			produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<FileIngestResponse> ingest(
-			@RequestPart("request")
-			@RequestBody(content = @Content(encoding = @Encoding(name = "request", contentType = MediaType.APPLICATION_JSON_VALUE)))
-			@Parameter(
-					description = "File ingest request accompanying the file",
-					content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)) final FileIngestRequest fileIngestRequest,
-			@RequestPart(value = "site_file") @Parameter(description = "Site file") final MultipartFile siteFile);
+			@RequestPart("request") final String fileIngestRequestJSON,
+			@RequestPart(value = "site_file") final MultipartFile siteFile);
 }

--- a/api/src/test/java/fi/poltsi/vempain/admin/api/request/file/FileIngestRequestUTC.java
+++ b/api/src/test/java/fi/poltsi/vempain/admin/api/request/file/FileIngestRequestUTC.java
@@ -1,0 +1,243 @@
+package fi.poltsi.vempain.admin.api.request.file;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class FileIngestRequestUTC {
+
+	private FileIngestRequest sample() {
+		return FileIngestRequest.builder()
+			.fileName("img_001.jpg")
+			.filePath("gallery/2025/08")
+			.mimeType("image/jpeg")
+			.comment("Some comment")
+			.metadata("{\"some-field\":\"some value\"}")
+			.sha256sum("abc123")
+			.userId(42L)
+			.galleryId(1001L)
+			.galleryName("Summer 2025")
+			.galleryDescription("A sunny album from August 2025")
+			.build();
+	}
+
+	@Test
+	void getFileName() {
+		assertEquals("img_001.jpg", sample().getFileName());
+	}
+
+	@Test
+	void getFilePath() {
+		assertEquals("gallery/2025/08", sample().getFilePath());
+	}
+
+	@Test
+	void getMimeType() {
+		assertEquals("image/jpeg", sample().getMimeType());
+	}
+
+	@Test
+	void getComment() {
+		assertEquals("Some comment", sample().getComment());
+	}
+
+	@Test
+	void getMetadata() {
+		assertEquals("{\"some-field\":\"some value\"}", sample().getMetadata());
+	}
+
+	@Test
+	void getSha256sum() {
+		assertEquals("abc123", sample().getSha256sum());
+	}
+
+	@Test
+	void getUserId() {
+		assertEquals(42L, sample().getUserId());
+	}
+
+	@Test
+	void getGalleryId() {
+		assertEquals(1001L, sample().getGalleryId());
+	}
+
+	@Test
+	void getGalleryName() {
+		assertEquals("Summer 2025", sample().getGalleryName());
+	}
+
+	@Test
+	void getGalleryDescription() {
+		assertEquals("A sunny album from August 2025", sample().getGalleryDescription());
+	}
+
+	@Test
+	void setFileName() {
+		FileIngestRequest r = sample();
+		r.setFileName("new.jpg");
+		assertEquals("new.jpg", r.getFileName());
+	}
+
+	@Test
+	void setFilePath() {
+		FileIngestRequest r = sample();
+		r.setFilePath("other/path");
+		assertEquals("other/path", r.getFilePath());
+	}
+
+	@Test
+	void setMimeType() {
+		FileIngestRequest r = sample();
+		r.setMimeType("image/png");
+		assertEquals("image/png", r.getMimeType());
+	}
+
+	@Test
+	void setComment() {
+		FileIngestRequest r = sample();
+		r.setComment("Updated");
+		assertEquals("Updated", r.getComment());
+	}
+
+	@Test
+	void setMetadata() {
+		FileIngestRequest r = sample();
+		r.setMetadata("{}");
+		assertEquals("{}", r.getMetadata());
+	}
+
+	@Test
+	void setSha256sum() {
+		FileIngestRequest r = sample();
+		r.setSha256sum("def456");
+		assertEquals("def456", r.getSha256sum());
+	}
+
+	@Test
+	void setUserId() {
+		FileIngestRequest r = sample();
+		r.setUserId(99L);
+		assertEquals(99L, r.getUserId());
+	}
+
+	@Test
+	void setGalleryId() {
+		FileIngestRequest r = sample();
+		r.setGalleryId(222L);
+		assertEquals(222L, r.getGalleryId());
+	}
+
+	@Test
+	void setGalleryName() {
+		FileIngestRequest r = sample();
+		r.setGalleryName("New Name");
+		assertEquals("New Name", r.getGalleryName());
+	}
+
+	@Test
+	void setGalleryDescription() {
+		FileIngestRequest r = sample();
+		r.setGalleryDescription("New Desc");
+		assertEquals("New Desc", r.getGalleryDescription());
+	}
+
+	@Test
+	void testEquals() {
+		FileIngestRequest a = sample();
+		FileIngestRequest b = sample();
+		assertEquals(a, b);
+		assertEquals(a.hashCode(), b.hashCode());
+		b.setFileName("different.jpg");
+		assertNotEquals(a, b);
+	}
+
+	@Test
+	void canEqual() {
+		FileIngestRequest a = sample();
+		assertTrue(a.canEqual(sample()));
+		// Different class
+		assertFalse(a.canEqual("not a request"));
+	}
+
+	@Test
+	void testHashCode() {
+		FileIngestRequest a = sample();
+		FileIngestRequest b = sample();
+		assertEquals(a.hashCode(), b.hashCode());
+		b.setSha256sum("changed");
+		assertNotEquals(a.hashCode(), b.hashCode());
+	}
+
+	@Test
+	void testToString() {
+		String s = sample().toString();
+		assertTrue(s.contains("FileIngestRequest"));
+		assertTrue(s.contains("img_001.jpg"));
+		assertTrue(s.contains("image/jpeg"));
+	}
+
+	@Test
+	void builder() {
+		FileIngestRequest r = FileIngestRequest.builder()
+			.fileName("f.txt")
+			.filePath("x/y")
+			.mimeType("text/plain")
+			.comment("c")
+			.metadata("{}")
+			.sha256sum("sum")
+			.userId(1L)
+			.galleryId(2L)
+			.galleryName("G")
+			.galleryDescription("Desc")
+			.build();
+		assertAll(
+			() -> assertEquals("f.txt", r.getFileName()),
+			() -> assertEquals("x/y", r.getFilePath()),
+			() -> assertEquals("text/plain", r.getMimeType()),
+			() -> assertEquals("c", r.getComment()),
+			() -> assertEquals("{}", r.getMetadata()),
+			() -> assertEquals("sum", r.getSha256sum()),
+			() -> assertEquals(1L, r.getUserId()),
+			() -> assertEquals(2L, r.getGalleryId()),
+			() -> assertEquals("G", r.getGalleryName()),
+			() -> assertEquals("Desc", r.getGalleryDescription())
+		);
+	}
+
+	@Test
+	void jsonDeserialization() throws Exception {
+		String json = """
+		{
+		  "file_name": "img_001.png",
+		  "file_path": "test-gallery",
+		  "mime_type": "image/png",
+		  "comment": "Some comment",
+		  "metadata": "{\\"some_field\\":\\"some value\\"}",
+		  "sha256sum": "3f786850e387550fdab836ed7e6dc881de23001b",
+		  "user_id": 1,
+		  "gallery_id": 1,
+		  "gallery_name": "Summer 2025",
+		  "gallery_description": "A sunny album from August 2025"
+		}
+		""";
+		ObjectMapper mapper = new ObjectMapper();
+		FileIngestRequest r = mapper.readValue(json, FileIngestRequest.class);
+		assertAll(
+			() -> assertEquals("img_001.png", r.getFileName()),
+			() -> assertEquals("test-gallery", r.getFilePath()),
+			() -> assertEquals("image/png", r.getMimeType()),
+			() -> assertEquals("Some comment", r.getComment()),
+			() -> assertEquals("{\"some_field\":\"some value\"}", r.getMetadata()),
+			() -> assertEquals("3f786850e387550fdab836ed7e6dc881de23001b", r.getSha256sum()),
+			() -> assertEquals(1L, r.getUserId()),
+			() -> assertEquals(1L, r.getGalleryId()),
+			() -> assertEquals("Summer 2025", r.getGalleryName()),
+			() -> assertEquals("A sunny album from August 2025", r.getGalleryDescription())
+		);
+	}
+}

--- a/service/src/main/java/fi/poltsi/vempain/admin/service/file/FileIngestService.java
+++ b/service/src/main/java/fi/poltsi/vempain/admin/service/file/FileIngestService.java
@@ -114,6 +114,7 @@ public class FileIngestService {
 										   .normalize();
 
 			ensureWithinBase(targetDir, basePath);
+			log.info("Creating target directory: {}", targetDir);
 			Files.createDirectories(targetDir);
 
 			final Path targetFile = targetDir.resolve(cleanFileName)


### PR DESCRIPTION
This pull request introduces several improvements to the file ingest API and its supporting infrastructure. The main changes are the refactoring of the file ingest endpoint to accept JSON as a string, the addition of comprehensive unit tests for the `FileIngestRequest` model, and enhancements to the build system to support code coverage and modern test frameworks.

### API and Controller Refactoring

* The `FileIngestAPI` interface and its implementation in `FileIngestController` have been refactored to accept the file ingest request as a JSON string (`fileIngestRequestJSON`) rather than a strongly typed object. The controller now deserializes this JSON using an `ObjectMapper` and handles invalid input gracefully by returning a bad request response. (`[[1]](diffhunk://#diff-b2963af8419d15cb1a4a0631ec884b67d37c65327b78ef29e00eeb024bc99f42L36-R32)`, `[[2]](diffhunk://#diff-fe37f2838b6fa7392eec09786083372465be51d6291d3cf620d617488dd5be7aR21-R35)`)
* Unused OpenAPI and Swagger annotations were removed from `FileIngestAPI`, simplifying the interface. (`[api/src/main/java/fi/poltsi/vempain/admin/rest/file/FileIngestAPI.javaL3-L9](diffhunk://#diff-b2963af8419d15cb1a4a0631ec884b67d37c65327b78ef29e00eeb024bc99f42L3-L9)`)

### Testing Improvements

* A new unit test class, `FileIngestRequestUTC`, was added to thoroughly test the `FileIngestRequest` model, including its builder, getters, setters, equality, hash code, string representation, and JSON deserialization. (`[api/src/test/java/fi/poltsi/vempain/admin/api/request/file/FileIngestRequestUTC.javaR1-R243](diffhunk://#diff-bbc048a9255535cf8794590e11dc12f48cdf2c150c3de949435e416d8f626cc7R1-R243)`)

### Build System and Code Coverage

* The `api/build.gradle` file was updated to include the Jacoco plugin for code coverage and to use JUnit Jupiter and Mockito for testing. The build now generates XML coverage reports and uses the JUnit Platform for running tests. (`[[1]](diffhunk://#diff-25d49275b34eb312234a2e92eaef61ca1e0a324f9f534cdf8d5e24b51135c3c6R5)`, `[[2]](diffhunk://#diff-25d49275b34eb312234a2e92eaef61ca1e0a324f9f534cdf8d5e24b51135c3c6R52-R56)`, `[[3]](diffhunk://#diff-25d49275b34eb312234a2e92eaef61ca1e0a324f9f534cdf8d5e24b51135c3c6R95-R113)`)

### OpenAPI Documentation

* The OpenAPI definition in `VempainServiceApiDefinition.java` was updated to clarify the service name and make the server port configurable via `${server.port}`. (`[api/src/main/java/fi/poltsi/vempain/admin/VempainServiceApiDefinition.javaL8-R9](diffhunk://#diff-e0a1b1762943694c7178e2b9cb536cee507da504e6f1a96190d3346a092e8036L8-R9)`)

### Logging and Diagnostics

* Additional logging was added to the file ingest service to indicate when target directories are created during file uploads, aiding in diagnostics and troubleshooting. (`[service/src/main/java/fi/poltsi/vempain/admin/service/file/FileIngestService.javaR117](diffhunk://#diff-3ea64f1acbd995436455718de930bfc66d36e4cd6bed6965b5e7179aa9057c07R117)`)