### PR TITLE
Use kebab-case for JWT application variables

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,8 +13,8 @@ services:
       - spring.site-datasource.url=jdbc:postgresql://${ENV_VEMPAIN_SITE_DB_ADDRESS}:3306/${ENV_VEMPAIN_SITE_DB_NAME}?useSSL=false
       - spring.site-datasource.username=${ENV_VEMPAIN_SITE_DB_USER}
       - spring.site-datasource.password=${ENV_VEMPAIN_SITE_DB_PASSWORD}
-      - vempain.app.jwtSecret=your_jwt_secret_here
-      - vempain.app.jwtExpirationMs=86400000
+      - vempain.app.jwt-secret=your_jwt_secret_here
+      - vempain.app.jwt-expiration-ms=86400000
       - vempain.test=false
       - vempain.admin.file.site-file-directory=/vempain_admin/site-files
       - vempain.admin.ssh.user=${ENV_VEMPAIN_SITE_SSH_USER}

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,4 +13,4 @@ jjwtVersion=0.13.0
 # https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core
 jacksonVersion=2.19.2
 # https://github.com/Vempain/vempain-auth/packages/2614500
-vempainAuthVersion=0.9.8
+vempainAuthVersion=0.9.9

--- a/service/src/main/java/fi/poltsi/vempain/SetupVerification.java
+++ b/service/src/main/java/fi/poltsi/vempain/SetupVerification.java
@@ -25,34 +25,39 @@ import java.util.stream.StreamSupport;
 @Component
 @AllArgsConstructor
 class SetupVerification implements ApplicationContextAware {
-	private final String TYPE_STRING  = "string";
-	private final String TYPE_NUMBER  = "number";
-	private final String TYPE_PATH    = "path";
+	private final String TYPE_STRING = "string";
+	private final String TYPE_NUMBER = "number";
+	private final String TYPE_PATH   = "path";
 	private final String TYPE_FILE   = "file";
 
-	private final String[][] requiredKeys = {{"vempain.admin.file.image-format", TYPE_STRING},
-											 {"vempain.admin.file.thumbnail-size", TYPE_NUMBER},
-											 {"vempain.admin.file.site-file-directory", TYPE_PATH},
-											 {"vempain.admin.ssh.user", TYPE_STRING},
-											 {"vempain.admin.ssh.home-dir", TYPE_PATH},
-											 {"vempain.admin.ssh.private-key", TYPE_PATH},
-											 {"vempain.cmd-line.exiftool", TYPE_FILE},
-											 {"vempain.site.ssh.address", TYPE_STRING},
-											 {"vempain.site.ssh.port", TYPE_NUMBER},
-											 {"vempain.site.ssh.user", TYPE_STRING},
-											 {"vempain.site.ssh.home-dir", TYPE_STRING}, // This needs to be a string because it is located on the remote
-											 {"vempain.site.www-root", TYPE_STRING},
-											 {"vempain.site.image-size", TYPE_NUMBER},
-											 {"spring.admin-datasource.url", TYPE_STRING},
-											 {"spring.admin-datasource.username", TYPE_STRING},
-											 {"spring.site-datasource.url", TYPE_STRING},
-											 {"spring.site-datasource.username", TYPE_STRING}};
+	private final String[][] requiredKeys = {
+			{"vempain.app.frontend-url", TYPE_STRING},
+			{"vempain.app.jwt-secret", TYPE_STRING},
+			{"vempain.admin.file.site-file-directory", TYPE_PATH},
+			{"vempain.admin.ssh.user", TYPE_STRING},
+			{"vempain.admin.ssh.home-dir", TYPE_PATH},
+			{"vempain.site.www-root", TYPE_STRING},
+			{"vempain.site.ssh.user", TYPE_STRING},
+			{"vempain.site.ssh.home-dir", TYPE_STRING}, // This needs to be a string because it is located on the remote
+			{"vempain.site.ssh.address", TYPE_STRING},
+			{"vempain.cmd-line.exiftool", TYPE_FILE},
+			// Following are already defined with default values, but we want to make sure they're of the correct type
+			{"vempain.app.jwt-expiration-ms", TYPE_NUMBER},
+			{"vempain.admin.file.thumbnail-size", TYPE_NUMBER},
+			{"vempain.site.image-size", TYPE_NUMBER},
+			{"vempain.site.ssh.port", TYPE_NUMBER},
+			{"vempain.cors.max-age", TYPE_NUMBER},
+			{"spring.admin-datasource.url", TYPE_STRING},
+			{"spring.admin-datasource.username", TYPE_STRING},
+			{"spring.site-datasource.url", TYPE_STRING},
+			{"spring.site-datasource.username", TYPE_STRING}};
 
 	private ApplicationContext applicationContext;
 
 	@EventListener
 	public void checkEssentialConfigurations(ContextRefreshedEvent event) {
-		final Environment env = event.getApplicationContext().getEnvironment();
+		final Environment env = event.getApplicationContext()
+									 .getEnvironment();
 
 		for (String[] keyPair : requiredKeys) {
 			var value = env.getProperty(keyPair[0]);
@@ -108,7 +113,8 @@ class SetupVerification implements ApplicationContextAware {
 
 	@EventListener
 	public void printAllConfiguration(ContextRefreshedEvent event) {
-		final Environment env = event.getApplicationContext().getEnvironment();
+		final Environment env = event.getApplicationContext()
+									 .getEnvironment();
 		log.info("====== Environment and configuration ======");
 		log.info("Active profiles: {}", Arrays.toString(env.getActiveProfiles()));
 		final MutablePropertySources sources = ((AbstractEnvironment) env).getPropertySources();
@@ -118,6 +124,7 @@ class SetupVerification implements ApplicationContextAware {
 					 .flatMap(Arrays::stream)
 					 .distinct()
 					 .filter(prop -> !(prop.contains("credentials") || prop.contains("password")))
+					 .sorted()
 					 .forEach(prop -> printProperty(env, prop));
 		log.info("===========================================");
 	}

--- a/service/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/service/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -51,12 +51,12 @@
       "description": "Session time-out, in seconds."
     },
     {
-      "name": "vempain.app.jwtSecret",
+      "name": "vempain.app.jwt-secret",
       "type": "java.lang.String",
       "description": "JWT secret passphrase, base64 encoded."
     },
     {
-      "name": "vempain.app.jwtExpirationMs",
+      "name": "vempain.app.jwt-expiration-ms",
       "type": "java.lang.Long",
       "description": "JWT timeout in milliseconds."
     },

--- a/service/src/main/resources/application.yaml
+++ b/service/src/main/resources/application.yaml
@@ -87,8 +87,8 @@ vempain:
   license-url: "https://www.gnu.org/licenses/old-licenses/gpl-2.0.html"
   app:
     frontend-url: override-me
-    jwtSecret: override-me
-    jwtExpirationMs: 86400000
+    jwt-secret: override-me
+    jwt-expiration-ms: 86400000
   test: true
   admin:
     file:

--- a/service/src/test/resources/application.properties
+++ b/service/src/test/resources/application.properties
@@ -21,8 +21,8 @@ vempain.site.www-root=/var/tmp/vempain-www
 vempain.site.thumb-directory=.thumb
 vempain.site.image-size=800
 vempain.devel=false
-vempain.app.jwtSecret=OUVENkFDQjk2REI2RTRFREE0QkQzREQ5RDRCRjhFM0YxNDA3MUJBQjVCNDExNEJBM0FFOEExMjI5MEUxRTQ5RAo=
-vempain.app.jwtExpirationMs=86400000
+vempain.app.jwt-secret=OUVENkFDQjk2REI2RTRFREE0QkQzREQ5RDRCRjhFM0YxNDA3MUJBQjVCNDExNEJBM0FFOEExMjI5MEUxRTQ5RAo=
+vempain.app.jwt-expiration-ms=86400000
 vempain.cmd-line.exiftool=/usr/bin/exiftool
 spring.flyway.enabled=true
 spring.flyway.admin.clean-disabled=false

--- a/service/src/test/resources/application.properties
+++ b/service/src/test/resources/application.properties
@@ -23,6 +23,7 @@ vempain.site.image-size=800
 vempain.devel=false
 vempain.app.jwt-secret=OUVENkFDQjk2REI2RTRFREE0QkQzREQ5RDRCRjhFM0YxNDA3MUJBQjVCNDExNEJBM0FFOEExMjI5MEUxRTQ5RAo=
 vempain.app.jwt-expiration-ms=86400000
+vempain.app.frontend-url=httops://localhost:3000
 vempain.cmd-line.exiftool=/usr/bin/exiftool
 spring.flyway.enabled=true
 spring.flyway.admin.clean-disabled=false


### PR DESCRIPTION
This pull request focuses on standardizing configuration property names related to JWT authentication across the codebase and updating required configuration checks. The changes ensure consistent use of kebab-case for property names, update documentation and metadata accordingly, and improve configuration validation in the application startup logic.

**Configuration property standardization:**

* Renamed JWT-related configuration properties from camelCase (`jwtSecret`, `jwtExpirationMs`) to kebab-case (`jwt-secret`, `jwt-expiration-ms`) in `docker-compose.yaml`, `application.yaml`, `application.properties`, and `additional-spring-configuration-metadata.json` for consistency and clarity. [[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9L16-R17) [[2]](diffhunk://#diff-5c7e087351d3e0d23c05bdde77bc132cae5e2c09412131f33acd5f1e4ba79df8L90-R91) [[3]](diffhunk://#diff-4df8d68e68167b1c98e3814f6e73614448f8217225d6e85a6eb4ffe5a9139304L24-R25) [[4]](diffhunk://#diff-1cb81e01c045f0554eeaa54edc6a91066fbecabb4e7c053f773fce5cda03c151L54-R59)

**Configuration validation improvements:**

* Updated the `requiredKeys` array in `SetupVerification.java` to check for the new kebab-case JWT property names and added validation for other configuration keys to ensure correct types.
* Improved formatting and sorting in configuration printing and validation logic in `SetupVerification.java` for better readability and maintainability. [[1]](diffhunk://#diff-72f4afacac766039ebb647cce272ebdf11caaa741134984fbab9bf2ccf4b37daL55-R60) [[2]](diffhunk://#diff-72f4afacac766039ebb647cce272ebdf11caaa741134984fbab9bf2ccf4b37daL111-R117) [[3]](diffhunk://#diff-72f4afacac766039ebb647cce272ebdf11caaa741134984fbab9bf2ccf4b37daR127)

**Dependency update:**

* Bumped `vempainAuthVersion` from `0.9.8` to `0.9.9` in `gradle.properties` to use the latest authentication library version.