### PR TITLE
Update dependency packages to latest

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -37,7 +37,6 @@ tasks.withType(Javadoc).configureEach {
 dependencies {
 	api "org.springframework.boot:spring-boot-jackson:${springBootVersion}"
 	api "org.springframework.boot:spring-boot-starter-webmvc:${springBootVersion}"
-	api "org.springframework.data:spring-data-jpa:${springBootVersion}"
 	// This needs to be built first in vempain-auth
 	api "fi.poltsi.vempain:vempain-auth-api:${vempainAuthVersion}"
 	api "fi.poltsi.vempain:vempain-file-backend-api:${vempainFileVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,24 +1,24 @@
 releaseVersion=0.0.1-SNAPSHOT
 javaVersion=25
 # https://mvnrepository.com/artifact/org.springframework.boot/spring-boot
-springBootVersion=4.0.2
+springBootVersion=4.0.5
 # https://mvnrepository.com/artifact/org.testcontainers/testcontainers
-testContainersVersion=2.0.3
+testContainersVersion=2.0.4
 # https://mvnrepository.com/artifact/io.freefair.lombok/io.freefair.lombok.gradle.plugin
 ioFreeFairLombok=9.2.0
-# https://mvnrepository.com/artifact/org.json/json/20251224
+# https://mvnrepository.com/artifact/org.json/json
 jsonVersion=20251224
 # https://mvnrepository.com/artifact/org.postgresql/postgresql
-postgresqlVersion=42.7.9
+postgresqlVersion=42.7.10
 # https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
 jjwtVersion=0.13.0
 # https://mvnrepository.com/artifact/org.junit/junit-bom
-junitVersion=6.0.2
+junitVersion=6.0.3
 # https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations
-swaggerVersion=2.2.42
-# https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter\
-mockitoVersion=5.21.0
+swaggerVersion=2.2.45
+# https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
+mockitoVersion=5.23.0
 # https://github.com/Vempain/vempain-auth/packages/2723219
-vempainAuthVersion=1.0.3
+vempainAuthVersion=1.0.5
 # https://github.com/Vempain/vempain-file-backend/packages/2726778
-vempainFileVersion=1.0.3
+vempainFileVersion=1.0.8

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,6 @@ swaggerVersion=2.2.45
 # https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
 mockitoVersion=5.23.0
 # https://github.com/Vempain/vempain-auth/packages/2723219
-vempainAuthVersion=1.0.5
+vempainAuthVersion=1.0.6
 # https://github.com/Vempain/vempain-file-backend/packages/2726778
 vempainFileVersion=1.0.8

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -59,13 +59,13 @@ dependencies {
 	// https://mvnrepository.com/artifact/org.apache.commons/commons-text
 	implementation "org.apache.commons:commons-text:1.15.0"
 	// https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
-	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1"
+	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.2"
 	runtimeOnly "org.postgresql:postgresql:${postgresqlVersion}"
 	implementation "org.json:json:${jsonVersion}"
 	// https://mvnrepository.com/artifact/net.coobird/thumbnailator
 	implementation "net.coobird:thumbnailator:0.4.21"
 	// https://mvnrepository.com/artifact/com.github.mwiede/jsch
-	implementation "com.github.mwiede:jsch:2.27.7"
+	implementation "com.github.mwiede:jsch:2.27.9"
 	// https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api
 	implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.5"
 	// https://mvnrepository.com/artifact/jakarta.annotation/jakarta.annotation-api
@@ -85,8 +85,6 @@ dependencies {
 	testImplementation "org.testcontainers:testcontainers-junit-jupiter:${testContainersVersion}"
 	testImplementation "org.testcontainers:testcontainers-postgresql:${testContainersVersion}"
 	testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
-	// https://mvnrepository.com/artifact/org.springframework.security/spring-security-test
-	testImplementation "org.springframework.security:spring-security-test:7.0.2"
 }
 
 application {


### PR DESCRIPTION
This pull request primarily updates dependency versions across the project to keep libraries current and secure. It also removes an unused dependency from the API module and cleans up test dependencies in the service module.

**Dependency updates:**

* Updated several dependency versions in `gradle.properties`, including `springBootVersion`, `testContainersVersion`, `postgresqlVersion`, `junitVersion`, `swaggerVersion`, `mockitoVersion`, `vempainAuthVersion`, and `vempainFileVersion` to their latest releases.
* Upgraded `springdoc-openapi-starter-webmvc-ui` and `jsch` dependencies in `service/build.gradle` to newer versions for improved stability and security.

**Dependency removals and cleanup:**

* Removed the `spring-data-jpa` dependency from the API module's `build.gradle`, possibly because it is no longer needed or has been relocated.
* Removed the direct test dependency on `spring-security-test` from `service/build.gradle`, likely due to redundancy or lack of usage.