### PR TITLE
Move all dependency versions to gradle.properties

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -41,8 +41,7 @@ dependencies {
 	api "fi.poltsi.vempain:vempain-auth-api:${vempainAuthVersion}"
 	api "fi.poltsi.vempain:vempain-file-backend-api:${vempainFileVersion}"
 	implementation "io.swagger.core.v3:swagger-annotations:${swaggerVersion}"
-	// https://mvnrepository.com/artifact/jakarta.validation/jakarta.validation-api
-	implementation "jakarta.validation:jakarta.validation-api:3.1.1"
+	implementation "jakarta.validation:jakarta.validation-api:${jakartaValidationApiVersion}"
 	testImplementation "org.mockito:mockito-junit-jupiter:${mockitoVersion}"
 	testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"
 	testImplementation "org.junit.platform:junit-platform-launcher:${junitVersion}"
@@ -86,7 +85,7 @@ publishing {
 }
 
 jacoco {
-	toolVersion = "0.8.13"
+	toolVersion = "${jacocoVersion}"
 }
 
 tasks.named('test') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,9 +16,33 @@ jjwtVersion=0.13.0
 junitVersion=6.0.3
 # https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations
 swaggerVersion=2.2.48
+# https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
+springdocVersion=3.0.3
 # https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
 mockitoVersion=5.23.0
 # https://github.com/Vempain/vempain-auth/packages/2723219
 vempainAuthVersion=1.0.10
 # https://github.com/Vempain/vempain-file-backend/packages/2726778
 vempainFileVersion=1.0.16
+# https://mvnrepository.com/artifact/commons-codec/commons-codec
+commonsCodecVersion=1.21.0
+# https://mvnrepository.com/artifact/org.apache.commons/commons-text
+commonsTextVersion=1.15.0
+# https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api
+jakartaBindApiVersion=4.0.5
+# https://mvnrepository.com/artifact/jakarta.annotation/jakarta.annotation-api
+jakartaAnnotationApiVersion=3.0.0
+# https://mvnrepository.com/artifact/jakarta.validation/jakarta.validation-api
+jakartaValidationApiVersion=3.1.1
+# https://mvnrepository.com/artifact/net.coobird/thumbnailator
+thumbnailatorVersion=0.4.21
+# https://mvnrepository.com/artifact/com.github.mwiede/jsch
+jschVersion=2.28.0
+# https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-annotations
+spotbugsAnnotationsVersion=4.9.8
+# https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
+commonsLang3Version=3.20.0
+# https://mvnrepository.com/artifact/io.spring.gradle/dependency-management-plugin
+gradleSpringPluginVersion=1.1.7
+# https://mvnrepository.com/artifact/org.jacoco/jacoco
+jacocoVersion=0.8.13

--- a/service/build.gradle
+++ b/service/build.gradle
@@ -3,8 +3,8 @@ import org.apache.tools.ant.filters.ReplaceTokens
 plugins {
 	id 'application'
 	id 'org.springframework.boot' version "${springBootVersion}"
-	// https://mvnrepository.com/artifact/io.freefair.lombok/io.freefair.lombok.gradle.plugin
 	id "io.freefair.lombok" version "${ioFreeFairLombok}"
+	id 'io.spring.dependency-management' version "${gradleSpringPluginVersion}"
 	id "jacoco"
 }
 
@@ -56,26 +56,17 @@ dependencies {
 	implementation "org.springframework.boot:spring-boot-starter-data-jpa:${springBootVersion}"
 	implementation "org.springframework.boot:spring-boot-starter-flyway:${springBootVersion}"
 	implementation "io.jsonwebtoken:jjwt-api:${jjwtVersion}"
-	// https://mvnrepository.com/artifact/org.apache.commons/commons-text
-	implementation "org.apache.commons:commons-text:1.15.0"
-	// https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
-	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.3"
+	implementation "org.apache.commons:commons-text:${commonsTextVersion}"
+	implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${springdocVersion}"
 	runtimeOnly "org.postgresql:postgresql:${postgresqlVersion}"
 	implementation "org.json:json:${jsonVersion}"
-	// https://mvnrepository.com/artifact/net.coobird/thumbnailator
-	implementation "net.coobird:thumbnailator:0.4.21"
-	// https://mvnrepository.com/artifact/com.github.mwiede/jsch
-	implementation "com.github.mwiede:jsch:2.28.0"
-	// https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api
-	implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.5"
-	// https://mvnrepository.com/artifact/jakarta.annotation/jakarta.annotation-api
-	implementation "jakarta.annotation:jakarta.annotation-api:3.0.0"
-	// https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-annotations
-	implementation "com.github.spotbugs:spotbugs-annotations:4.9.8"
-	// https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
-	implementation "org.apache.commons:commons-lang3:3.20.0"
-	// https://mvnrepository.com/artifact/commons-codec/commons-codec
-	implementation "commons-codec:commons-codec:1.21.0"
+	implementation "net.coobird:thumbnailator:${thumbnailatorVersion}"
+	implementation "com.github.mwiede:jsch:${jschVersion}"
+	implementation "jakarta.xml.bind:jakarta.xml.bind-api:${jakartaBindApiVersion}"
+	implementation "jakarta.annotation:jakarta.annotation-api:${jakartaAnnotationApiVersion}"
+	implementation "com.github.spotbugs:spotbugs-annotations:${spotbugsAnnotationsVersion}"
+	implementation "org.apache.commons:commons-lang3:${commonsLang3Version}"
+	implementation "commons-codec:commons-codec:${commonsCodecVersion}"
 	runtimeOnly "io.jsonwebtoken:jjwt-impl:${jjwtVersion}"
 	runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"
 	testImplementation "org.springframework.boot:spring-boot-starter-test:${springBootVersion}"
@@ -95,7 +86,7 @@ application {
 compileJava.inputs.files(processResources)
 
 jacoco {
-	toolVersion = "0.8.13"
+	toolVersion = "${jacocoVersion}"
 }
 
 tasks.named('test') {


### PR DESCRIPTION
This pull request updates the build configuration to centralize and standardize dependency version management by moving version numbers into `gradle.properties` and referencing them in the Gradle build files. It also introduces the Spring dependency management plugin to the service module. These changes improve maintainability and make it easier to update dependencies across the project.

**Dependency version management improvements:**

* Moved all dependency version numbers (such as `commons-text`, `springdoc-openapi`, `thumbnailator`, `jsch`, `jakarta.xml.bind-api`, `jakarta.annotation-api`, `spotbugs-annotations`, `commons-lang3`, `commons-codec`, and `jacoco`) into `gradle.properties` for centralized management. The build files now reference these properties instead of hardcoding versions. [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19R19-R48) [[2]](diffhunk://#diff-7af75b543199dde7b73517b9d67651db7f9208dbe566d9d725fd96bdb4a1f445L59-R69) [[3]](diffhunk://#diff-25d49275b34eb312234a2e92eaef61ca1e0a324f9f534cdf8d5e24b51135c3c6L44-R44) [[4]](diffhunk://#diff-25d49275b34eb312234a2e92eaef61ca1e0a324f9f534cdf8d5e24b51135c3c6L89-R88) [[5]](diffhunk://#diff-7af75b543199dde7b73517b9d67651db7f9208dbe566d9d725fd96bdb4a1f445L98-R89)

**Build system enhancements:**

* Added the `io.spring.dependency-management` Gradle plugin to the service module for better dependency management and alignment with Spring best practices.

These changes make the build process more maintainable and consistent, reducing the risk of version conflicts and simplifying future upgrades.