### PR TITLE
Update AGENTS.md regarding JSON fields being snake_case

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -31,6 +31,9 @@
 
 ## Project-specific conventions
 - JSON DTOs commonly use **snake_case** via Jackson naming annotations even when Java fields are camelCase. Example: `WebSiteUserRequest` / `WebSiteUserResponse`.
+- JSON API fields are mandatory snake_case across this repo; do not introduce camelCase JSON keys in DTO annotations, request/response payloads, or API docs.
+- Prefer Jackson v3 `tools.jackson.databind.*` naming/mapper APIs for DTO JSON behavior; keep non-`tools.jackson` annotations only when there is no
+  `tools.jackson` equivalent available in current dependencies.
 - Entities often provide `toResponse()` helpers; keep response mapping close to the entity when the repo already follows that pattern (see `WebSiteUser`).
 - Preserve request parameter normalization already present in services instead of moving it into controllers. Example: `FileService.findAllSiteFilesAsPageableResponseFiltered()` normalizes filter columns and remaps sort properties in `sanitizePageable()`.
 - Security is mostly delegated to the external `vempain-auth` packages, but local controllers still explicitly call `accessService.checkAuthentication()` and write paths use `accessService.getValidUserId()` for audit fields.

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,9 +21,9 @@ springdocVersion=3.0.3
 # https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
 mockitoVersion=5.23.0
 # https://github.com/Vempain/vempain-auth/packages/2723219
-vempainAuthVersion=1.0.10
+vempainAuthVersion=1.0.11
 # https://github.com/Vempain/vempain-file-backend/packages/2726778
-vempainFileVersion=1.0.16
+vempainFileVersion=1.0.24
 # https://mvnrepository.com/artifact/commons-codec/commons-codec
 commonsCodecVersion=1.21.0
 # https://mvnrepository.com/artifact/org.apache.commons/commons-text


### PR DESCRIPTION
This pull request introduces updated project conventions for JSON APIs and upgrades key dependencies to their latest versions. The most important changes are summarized below:

**Project conventions and documentation:**

* Updated `AGENTS.md` to clarify that all JSON API fields must use snake_case, and to standardize on Jackson v3 `tools.jackson.databind.*` APIs for DTO JSON behavior. Non-`tools.jackson` annotations should only be used if no equivalent exists.

**Dependency upgrades:**

* Upgraded `vempain-auth` dependency from version `1.0.10` to `1.0.11` in `gradle.properties`.
* Upgraded `vempain-file-backend` dependency from version `1.0.16` to `1.0.24` in `gradle.properties`.