### PR TITLE
Bump dependencies to latest

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,48 +1,48 @@
 releaseVersion=0.0.1-SNAPSHOT
 javaVersion=25
 # https://mvnrepository.com/artifact/org.springframework.boot/spring-boot
-springBootVersion=4.0.6
+springBootVersion=4.1.0
 # https://mvnrepository.com/artifact/org.testcontainers/testcontainers
 testContainersVersion=2.0.5
 # https://mvnrepository.com/artifact/io.freefair.lombok/io.freefair.lombok.gradle.plugin
-ioFreeFairLombok=9.2.0
+ioFreeFairLombok=9.5.0
 # https://mvnrepository.com/artifact/org.json/json
-jsonVersion=20251224
+jsonVersion=20260522
 # https://mvnrepository.com/artifact/org.postgresql/postgresql
-postgresqlVersion=42.7.10
+postgresqlVersion=42.7.11
 # https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
 jjwtVersion=0.13.0
 # https://mvnrepository.com/artifact/org.junit/junit-bom
-junitVersion=6.0.3
+junitVersion=6.1.1
 # https://mvnrepository.com/artifact/io.swagger.core.v3/swagger-annotations
-swaggerVersion=2.2.48
+swaggerVersion=2.2.49
 # https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
 springdocVersion=3.0.3
 # https://mvnrepository.com/artifact/org.mockito/mockito-junit-jupiter
 mockitoVersion=5.23.0
 # https://github.com/Vempain/vempain-auth/packages/2723219
 vempainAuthVersion=1.0.13
-# https://github.com/Vempain/vempain-file-backend/packages/2726778
-vempainFileVersion=1.0.24
 # https://mvnrepository.com/artifact/commons-codec/commons-codec
-commonsCodecVersion=1.21.0
-# https://mvnrepository.com/artifact/org.apache.commons/commons-text
-commonsTextVersion=1.15.0
+commonsCodecVersion=1.22.0
 # https://mvnrepository.com/artifact/jakarta.xml.bind/jakarta.xml.bind-api
 jakartaBindApiVersion=4.0.5
 # https://mvnrepository.com/artifact/jakarta.annotation/jakarta.annotation-api
 jakartaAnnotationApiVersion=3.0.0
-# https://mvnrepository.com/artifact/jakarta.validation/jakarta.validation-api
-jakartaValidationApiVersion=3.1.1
 # https://mvnrepository.com/artifact/net.coobird/thumbnailator
 thumbnailatorVersion=0.4.21
-# https://mvnrepository.com/artifact/com.github.mwiede/jsch
-jschVersion=2.28.0
-# https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-annotations
-spotbugsAnnotationsVersion=4.9.8
-# https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
-commonsLang3Version=3.20.0
 # https://mvnrepository.com/artifact/io.spring.gradle/dependency-management-plugin
 gradleSpringPluginVersion=1.1.7
 # https://mvnrepository.com/artifact/org.jacoco/jacoco
-jacocoVersion=0.8.13
+jacocoVersion=0.8.15
+# https://mvnrepository.com/artifact/com.github.mwiede/jsch
+jschVersion=2.28.3
+# https://mvnrepository.com/artifact/com.github.spotbugs/spotbugs-annotations
+spotbugsAnnotationsVersion=4.10.2
+# https://mvnrepository.com/artifact/org.apache.commons/commons-lang3
+commonsLang3Version=3.20.0
+# https://github.com/Vempain/vempain-file-backend/packages/2726778
+vempainFileVersion=1.0.30
+# https://mvnrepository.com/artifact/org.apache.commons/commons-text
+commonsTextVersion=1.15.0
+# https://mvnrepository.com/artifact/jakarta.validation/jakarta.validation-api
+jakartaValidationApiVersion=3.1.1


### PR DESCRIPTION
This pull request updates several dependency versions in the `gradle.properties` file to keep the project up-to-date with the latest releases and security patches. It also reorders some properties for consistency and adds missing version properties.

**Dependency version updates:**

* Upgraded `springBootVersion` to `4.1.0`, `ioFreeFairLombok` to `9.5.0`, `jsonVersion` to `20260522`, `postgresqlVersion` to `42.7.11`, `junitVersion` to `6.1.1`, `swaggerVersion` to `2.2.49`, `commonsCodecVersion` to `1.22.0`, `jschVersion` to `2.28.3`, and `spotbugsAnnotationsVersion` to `4.10.2`.
* Updated `vempainFileVersion` from `1.0.24` to `1.0.30` and reordered its declaration for consistency.

**Property additions and reordering:**

* Re-added or moved properties for `gradleSpringPluginVersion`, `jacocoVersion`, `commonsTextVersion`, and `jakartaValidationApiVersion` to improve organization and ensure all required versions are present.