### PR TITLE
Add gallery list dto

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Paginated page, site-file, gallery, and website-resource endpoints use `POST` re
 `content` and pagination metadata. Legacy query-parameter pagination endpoints are no longer supported. Page access checks are applied before slicing, so
 pagination metadata only includes pages visible to the current user.
 
-Gallery dropdowns use `POST /content-management/galleries/paged-without-files`, which returns the same
-`PagedResponse` metadata while avoiding gallery-file joins and file loading. Use the regular
-`/paged` endpoint when file counts or file details are required.
+Gallery dropdowns use `POST /content-management/galleries/paged-list`, which returns
+`FileGroupListResponse` items containing gallery metadata and `file_count` without loading file details. Page-linked gallery lists use
+`GET /content-management/galleries/page/{pageId}/list` with the same lightweight response shape. Use `/paged` when full gallery file details are required. The
+legacy `/paged-without-files` endpoint remains available for compatibility.
 
 ## Running in Docker
 

--- a/api/src/main/java/fi/poltsi/vempain/admin/api/response/file/FileGroupListResponse.java
+++ b/api/src/main/java/fi/poltsi/vempain/admin/api/response/file/FileGroupListResponse.java
@@ -1,0 +1,23 @@
+package fi.poltsi.vempain.admin.api.response.file;
+
+import fi.poltsi.vempain.auth.api.response.AbstractResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.experimental.SuperBuilder;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.annotation.JsonNaming;
+
+@EqualsAndHashCode(callSuper = true)
+@SuperBuilder
+@Data
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
+@Schema(description = "Lightweight gallery response for lists and selectors")
+public class FileGroupListResponse extends AbstractResponse {
+	@Schema(description = "Gallery short name", example = "Summer holiday")
+	private String shortName;
+	@Schema(description = "Gallery description", example = "Photos from the summer holiday")
+	private String description;
+	@Schema(description = "Number of files associated with the gallery", example = "42")
+	private long   fileCount;
+}

--- a/api/src/main/java/fi/poltsi/vempain/admin/rest/file/GalleryAPI.java
+++ b/api/src/main/java/fi/poltsi/vempain/admin/rest/file/GalleryAPI.java
@@ -7,6 +7,7 @@ import fi.poltsi.vempain.admin.api.request.file.GalleryRequest;
 import fi.poltsi.vempain.admin.api.response.DeleteResponse;
 import fi.poltsi.vempain.admin.api.response.PageResponse;
 import fi.poltsi.vempain.admin.api.response.PublishResponse;
+import fi.poltsi.vempain.admin.api.response.file.FileGroupListResponse;
 import fi.poltsi.vempain.admin.api.response.file.GalleryResponse;
 import fi.poltsi.vempain.auth.api.request.PagedRequest;
 import fi.poltsi.vempain.auth.api.response.PagedResponse;
@@ -70,6 +71,21 @@ public interface GalleryAPI {
 	@GetMapping(value = MAIN_PATH + "/page/{pageId}", produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<List<GalleryResponse>> getGalleriesByPage(@PathVariable(name = "pageId") long pageId,
 	                                                         @RequestParam(name = "details") @NotNull QueryDetailEnum queryDetailEnum);
+
+	@Operation(summary = "Get lightweight galleries linked to a page",
+			   description = "Fetch gallery metadata and file counts for galleries linked to a given page without loading file details.",
+			   tags = "GalleryAPI")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200", description = "Got a lightweight list of galleries",
+						 content = {@Content(array = @ArraySchema(schema = @Schema(implementation = FileGroupListResponse.class)),
+											 mediaType = MediaType.APPLICATION_JSON_VALUE)}),
+			@ApiResponse(responseCode = "400", description = "Invalid request issued", content = @Content),
+			@ApiResponse(responseCode = "401", description = "Unauthorized access", content = @Content),
+			@ApiResponse(responseCode = "500", description = "Internal server error", content = @Content)
+	})
+	@SecurityRequirement(name = "******")
+	@GetMapping(value = MAIN_PATH + "/page/{pageId}/list", produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<List<FileGroupListResponse>> getGalleryListByPage(@PathVariable(name = "pageId") long pageId);
 
 	@Operation(summary = "Fetch a specific gallery", description = "Return the requested gallery", tags = "GalleryAPI")
 	@Parameter(name = "gallery_id", example = "123", description = "ID of the gallery to be retrieved", required = true)
@@ -210,6 +226,22 @@ public interface GalleryAPI {
 	@SecurityRequirement(name = "******")
 	@PostMapping(value = MAIN_PATH + "/paged-without-files", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<PagedResponse<GalleryResponse>> getPagedGalleriesWithoutFiles(@Valid @RequestBody PagedRequest request);
+
+	@Operation(summary = "Get a lightweight page of galleries",
+			   description = "Filter and paginate galleries without loading associated file details. The response contains gallery metadata and file_count for list and selector use.",
+			   tags = "GalleryAPI")
+	@ApiResponses(value = {
+			@ApiResponse(responseCode = "200",
+						 description = "Paged lightweight gallery result",
+						 content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+											schema = @Schema(implementation = PagedResponse.class))),
+			@ApiResponse(responseCode = "400", description = "Invalid request issued", content = @Content),
+			@ApiResponse(responseCode = "401", description = "Unauthorized access", content = @Content),
+			@ApiResponse(responseCode = "500", description = "Internal server error", content = @Content)
+	})
+	@SecurityRequirement(name = "******")
+	@PostMapping(value = MAIN_PATH + "/paged-list", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<PagedResponse<FileGroupListResponse>> getPagedGalleryList(@Valid @RequestBody PagedRequest request);
 
 	@Operation(summary = "Publish selected galleries", description = "Publishes a list of galleries", tags = "GalleryAPI")
 	@io.swagger.v3.oas.annotations.parameters.RequestBody(description = "List of gallery IDs to publish", required = true,

--- a/service/src/main/java/fi/poltsi/vempain/admin/controller/file/GalleryController.java
+++ b/service/src/main/java/fi/poltsi/vempain/admin/controller/file/GalleryController.java
@@ -9,6 +9,7 @@ import fi.poltsi.vempain.admin.api.request.file.GalleryPublishRequest;
 import fi.poltsi.vempain.admin.api.request.file.GalleryRequest;
 import fi.poltsi.vempain.admin.api.response.DeleteResponse;
 import fi.poltsi.vempain.admin.api.response.PublishResponse;
+import fi.poltsi.vempain.admin.api.response.file.FileGroupListResponse;
 import fi.poltsi.vempain.admin.api.response.file.GalleryResponse;
 import fi.poltsi.vempain.admin.entity.PageGallery;
 import fi.poltsi.vempain.admin.rest.file.GalleryAPI;
@@ -56,12 +57,32 @@ public class GalleryController implements GalleryAPI {
 	}
 
 	@Override
+	public ResponseEntity<PagedResponse<FileGroupListResponse>> getPagedGalleryList(PagedRequest request) {
+		return ResponseEntity.ok(galleryService.findPagedGalleryListByUser(request));
+	}
+
+	@Override
 	public ResponseEntity<List<GalleryResponse>> getGalleriesByPage(long pageId, QueryDetailEnum queryDetailEnum) {
 		var pageGalleries = new ArrayList<GalleryResponse>();
 		var galleries = pageGalleryService.findPageGalleryByPageId(pageId);
 
 		for (PageGallery pageGallery : galleries) {
 			pageGalleries.add(galleryService.findById(pageGallery.getGalleryId()));
+		}
+
+		return ResponseEntity.ok(pageGalleries);
+	}
+
+	@Override
+	public ResponseEntity<List<FileGroupListResponse>> getGalleryListByPage(long pageId) {
+		var pageGalleries = new ArrayList<FileGroupListResponse>();
+		var galleries = pageGalleryService.findPageGalleryByPageId(pageId);
+
+		for (PageGallery pageGallery : galleries) {
+			var gallery = galleryService.findGalleryListById(pageGallery.getGalleryId());
+			if (gallery != null) {
+				pageGalleries.add(gallery);
+			}
 		}
 
 		return ResponseEntity.ok(pageGalleries);

--- a/service/src/main/java/fi/poltsi/vempain/admin/entity/file/Gallery.java
+++ b/service/src/main/java/fi/poltsi/vempain/admin/entity/file/Gallery.java
@@ -1,5 +1,6 @@
 package fi.poltsi.vempain.admin.entity.file;
 
+import fi.poltsi.vempain.admin.api.response.file.FileGroupListResponse;
 import fi.poltsi.vempain.admin.api.response.file.GalleryResponse;
 import fi.poltsi.vempain.admin.api.response.file.SiteFileResponse;
 import fi.poltsi.vempain.auth.api.response.AclResponse;
@@ -53,6 +54,7 @@ public class Gallery extends AbstractVempainEntity implements Serializable {
 			for (var siteFile : this.siteFiles) {
 				siteFileResponses.add(siteFile.toResponse());
 			}
+
 		}
 
 		var aclResponses = new ArrayList<AclResponse>();
@@ -72,6 +74,26 @@ public class Gallery extends AbstractVempainEntity implements Serializable {
 		                      .modifier(this.modifier)
 		                      .modified(this.modified)
 		                      .build();
+	}
+
+	public FileGroupListResponse getListResponse(long fileCount) {
+		var aclResponses = new ArrayList<AclResponse>();
+		if (this.acls != null) {
+			for (var acl : this.acls) {
+				aclResponses.add(acl.toResponse());
+			}
+		}
+		return FileGroupListResponse.builder()
+									.acls(aclResponses)
+									.id(this.id)
+									.shortName(this.shortname)
+									.description(this.description)
+									.fileCount(fileCount)
+									.creator(this.creator)
+									.created(this.created)
+									.modifier(this.modifier)
+									.modified(this.modified)
+									.build();
 	}
 
 	public WebSiteGallery getSiteGallery() {

--- a/service/src/main/java/fi/poltsi/vempain/admin/repository/file/GalleryRepositoryCustom.java
+++ b/service/src/main/java/fi/poltsi/vempain/admin/repository/file/GalleryRepositoryCustom.java
@@ -8,4 +8,6 @@ public interface GalleryRepositoryCustom {
 	Page<Gallery> searchGalleries(String searchTerm, boolean caseSensitive, Pageable pageable);
 
 	Page<Gallery> searchGalleriesWithoutFiles(String searchTerm, boolean caseSensitive, Pageable pageable);
+
+	Page<Gallery> searchGalleriesForList(String searchTerm, boolean caseSensitive, Pageable pageable);
 }

--- a/service/src/main/java/fi/poltsi/vempain/admin/repository/file/GalleryRepositoryImpl.java
+++ b/service/src/main/java/fi/poltsi/vempain/admin/repository/file/GalleryRepositoryImpl.java
@@ -32,6 +32,11 @@ public class GalleryRepositoryImpl implements GalleryRepositoryCustom {
 		return searchGalleries(searchTerm, caseSensitive, pageable, false);
 	}
 
+	@Override
+	public Page<Gallery> searchGalleriesForList(String searchTerm, boolean caseSensitive, Pageable pageable) {
+		return searchGalleries(searchTerm, caseSensitive, pageable, false);
+	}
+
 	private Page<Gallery> searchGalleries(String searchTerm, boolean caseSensitive, Pageable pageable, boolean includeFiles) {
 		List<String> tokens = tokenize(searchTerm);
 		String base = includeFiles

--- a/service/src/main/java/fi/poltsi/vempain/admin/service/file/GalleryService.java
+++ b/service/src/main/java/fi/poltsi/vempain/admin/service/file/GalleryService.java
@@ -2,6 +2,7 @@ package fi.poltsi.vempain.admin.service.file;
 
 import fi.poltsi.vempain.admin.api.QueryDetailEnum;
 import fi.poltsi.vempain.admin.api.request.file.GalleryRequest;
+import fi.poltsi.vempain.admin.api.response.file.FileGroupListResponse;
 import fi.poltsi.vempain.admin.api.response.file.GalleryResponse;
 import fi.poltsi.vempain.admin.entity.file.Gallery;
 import fi.poltsi.vempain.admin.entity.file.SiteFile;
@@ -177,6 +178,40 @@ public class GalleryService {
 	@Transactional(readOnly = true)
 	public PagedResponse<GalleryResponse> findPagedByUserWithoutFiles(PagedRequest request) {
 		return findPagedByUser(request, false);
+	}
+
+	@Transactional(readOnly = true)
+	public PagedResponse<FileGroupListResponse> findPagedGalleryListByUser(PagedRequest request) {
+		int safePage = request.getPage();
+		int safeSize = Math.min(request.getSize(), 200);
+		Sort sortSpec = buildSort(request.getSortBy(), request.getDirection());
+		Pageable pageable = PageRequest.of(safePage, safeSize, sortSpec);
+		var pageResult = galleryRepository.searchGalleriesForList(request.getSearch(), Boolean.TRUE.equals(request.getCaseSensitive()), pageable);
+		var items = new ArrayList<FileGroupListResponse>();
+
+		for (var gallery : pageResult.getContent()) {
+			if (accessService.hasReadPermission(gallery.getAclId())) {
+				populateGalleryWithAcls(gallery);
+				var fileCount = galleryFileService.findGalleryFileByGalleryId(gallery.getId())
+				                                  .size();
+				items.add(gallery.getListResponse(fileCount));
+			}
+		}
+
+		return PagedResponse.of(items, pageResult.getNumber(), pageResult.getSize(), pageResult.getTotalElements(),
+								pageResult.getTotalPages(), pageResult.isFirst(), pageResult.isLast());
+	}
+
+	@Transactional(readOnly = true)
+	public FileGroupListResponse findGalleryListById(long galleryId) {
+		var gallery = galleryRepository.findById(galleryId)
+		                               .orElse(null);
+		if (gallery == null || !accessService.hasReadPermission(gallery.getAclId())) {
+			return null;
+		}
+		populateGalleryWithAcls(gallery);
+		return gallery.getListResponse(galleryFileService.findGalleryFileByGalleryId(galleryId)
+		                                                 .size());
 	}
 
 	private PagedResponse<GalleryResponse> findPagedByUser(PagedRequest request, boolean includeFiles) {

--- a/service/src/test/java/fi/poltsi/vempain/admin/controller/file/GalleryControllerUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/admin/controller/file/GalleryControllerUTC.java
@@ -3,6 +3,7 @@ package fi.poltsi.vempain.admin.controller.file;
 import fi.poltsi.vempain.admin.api.request.PublishRequest;
 import fi.poltsi.vempain.admin.api.request.file.GalleryPublishRequest;
 import fi.poltsi.vempain.admin.api.request.file.GalleryRequest;
+import fi.poltsi.vempain.admin.api.response.file.FileGroupListResponse;
 import fi.poltsi.vempain.admin.api.response.file.GalleryResponse;
 import fi.poltsi.vempain.admin.entity.PageGallery;
 import fi.poltsi.vempain.admin.service.PageGalleryService;
@@ -45,6 +46,36 @@ class GalleryControllerUTC {
 		var result = galleryController.getPagedGalleriesWithoutFiles(request);
 
 		assertSame(response, result.getBody());
+	}
+
+	@Test
+	void getPagedGalleryListDelegatesToService() {
+		var request = new PagedRequest();
+		var response = PagedResponse.of(java.util.List.<FileGroupListResponse>of(), 0, 25, 0, 0, true, true);
+		when(galleryService.findPagedGalleryListByUser(request)).thenReturn(response);
+
+		var result = galleryController.getPagedGalleryList(request);
+
+		assertSame(response, result.getBody());
+		verify(galleryService).findPagedGalleryListByUser(request);
+	}
+
+	@Test
+	void getGalleryListByPageDelegatesToService() {
+		var gallery = fi.poltsi.vempain.admin.api.response.file.FileGroupListResponse.builder()
+		                                                                             .id(7L)
+		                                                                             .build();
+		var pageGallery = PageGallery.builder()
+		                             .galleryId(7L)
+		                             .build();
+		when(pageGalleryService.findPageGalleryByPageId(3L)).thenReturn(java.util.List.of(pageGallery));
+		when(galleryService.findGalleryListById(7L)).thenReturn(gallery);
+
+		var result = galleryController.getGalleryListByPage(3L);
+
+		assertSame(gallery, result.getBody()
+		                          .getFirst());
+		verify(galleryService).findGalleryListById(7L);
 	}
 
 	@Test

--- a/service/src/test/java/fi/poltsi/vempain/admin/service/file/GalleryServiceUTC.java
+++ b/service/src/test/java/fi/poltsi/vempain/admin/service/file/GalleryServiceUTC.java
@@ -2,6 +2,7 @@ package fi.poltsi.vempain.admin.service.file;
 
 import fi.poltsi.vempain.admin.api.QueryDetailEnum;
 import fi.poltsi.vempain.admin.api.request.file.GalleryRequest;
+import fi.poltsi.vempain.admin.api.response.file.FileGroupListResponse;
 import fi.poltsi.vempain.admin.api.response.file.GalleryResponse;
 import fi.poltsi.vempain.admin.entity.file.Gallery;
 import fi.poltsi.vempain.admin.entity.file.SiteFile;
@@ -9,6 +10,7 @@ import fi.poltsi.vempain.admin.repository.file.GalleryRepository;
 import fi.poltsi.vempain.admin.repository.file.SiteFileRepository;
 import fi.poltsi.vempain.admin.service.AccessService;
 import fi.poltsi.vempain.auth.api.request.PagedRequest;
+import fi.poltsi.vempain.auth.api.response.PagedResponse;
 import fi.poltsi.vempain.auth.entity.Acl;
 import fi.poltsi.vempain.auth.exception.VempainAclException;
 import fi.poltsi.vempain.auth.service.AclService;
@@ -427,6 +429,38 @@ class GalleryServiceUTC {
 
 		assertNotNull(result);
 		assertTrue(result.iterator().hasNext());
+	}
+
+	@Test
+	void findPagedGalleryListByUserReturnsMetadataAndFileCount() {
+		var request = request(25, "short_name", "asc", null, false);
+		when(galleryRepository.searchGalleriesForList(any(), anyBoolean(), any(Pageable.class)))
+				.thenReturn(new PageImpl<>(List.of(sampleGallery), Pageable.ofSize(25), 1));
+		when(accessService.hasReadPermission(10L)).thenReturn(true);
+		when(aclService.findAclByAclId(10L)).thenReturn(List.of(Acl.builder()
+		                                                           .aclId(10L)
+		                                                           .build()));
+		when(galleryFileService.findGalleryFileByGalleryId(1L)).thenReturn(List.of(
+				fi.poltsi.vempain.admin.entity.file.GalleryFile.builder()
+				                                               .galleryId(1L)
+				                                               .siteFileId(5L)
+				                                               .build(),
+				fi.poltsi.vempain.admin.entity.file.GalleryFile.builder()
+				                                               .galleryId(1L)
+				                                               .siteFileId(6L)
+				                                               .build()));
+
+		PagedResponse<FileGroupListResponse> result = galleryService.findPagedGalleryListByUser(request);
+
+		assertEquals(1, result.getContent()
+		                      .size());
+		assertEquals("test-gallery", result.getContent()
+		                                   .getFirst()
+		                                   .getShortName());
+		assertEquals(2, result.getContent()
+		                      .getFirst()
+		                      .getFileCount());
+		verify(galleryFileService).findGalleryFileByGalleryId(1L);
 	}
 
 }


### PR DESCRIPTION
This pull request introduces new lightweight endpoints and response types for listing galleries, optimized for selectors and list views where full file details are not needed. It adds the `FileGroupListResponse` DTO, new API endpoints, and supporting service and repository methods, along with corresponding tests. These changes improve performance and clarity when only gallery metadata and file counts are required, while maintaining compatibility with legacy endpoints.

**API and Endpoint Additions:**

* Added `FileGroupListResponse` DTO for lightweight gallery metadata and file count responses (`api/src/main/java/fi/poltsi/vempain/admin/api/response/file/FileGroupListResponse.java`).
* Introduced new endpoints in `GalleryAPI` for paginated and page-linked lightweight gallery lists: `POST /content-management/galleries/paged-list` and `GET /content-management/galleries/page/{pageId}/list` (`api/src/main/java/fi/poltsi/vempain/admin/rest/file/GalleryAPI.java`). [[1]](diffhunk://#diff-106cd4edbab1045d75031a3bc09c2d35815a2a55476674a19ded7c9f91a588bdR75-R89) [[2]](diffhunk://#diff-106cd4edbab1045d75031a3bc09c2d35815a2a55476674a19ded7c9f91a588bdR230-R245)

**Controller and Service Implementation:**

* Implemented controller methods to serve the new endpoints, delegating to service methods for fetching and assembling lightweight gallery data (`service/src/main/java/fi/poltsi/vempain/admin/controller/file/GalleryController.java`). [[1]](diffhunk://#diff-520b10cb7ad72bdea74247b7d1da34e96af1f4a5e7b0b526292d85057bebf92eR59-R63) [[2]](diffhunk://#diff-520b10cb7ad72bdea74247b7d1da34e96af1f4a5e7b0b526292d85057bebf92eR76-R90)
* Added service methods to fetch paginated gallery lists and individual gallery metadata with file counts, including access checks and ACL population (`service/src/main/java/fi/poltsi/vempain/admin/service/file/GalleryService.java`).

**Repository and Entity Support:**

* Extended repository interfaces and implementations to support lightweight gallery search (`service/src/main/java/fi/poltsi/vempain/admin/repository/file/GalleryRepositoryCustom.java`, `GalleryRepositoryImpl.java`). [[1]](diffhunk://#diff-ea98dabf17d41550080e25dad562db41bb26ecbf5d4c62a88912955d909ea2c3R11-R12) [[2]](diffhunk://#diff-1c2ffdf3249512732a7e11313e3192320ee15f062782a970a20ba6ffc6db2540R35-R39)
* Added `getListResponse` to `Gallery` entity for building `FileGroupListResponse` objects (`service/src/main/java/fi/poltsi/vempain/admin/entity/file/Gallery.java`).

**Documentation and Tests:**

* Updated documentation to describe new endpoints and clarify usage for selectors and lists, while noting legacy endpoint compatibility (`README.md`).
* Added and updated unit tests to cover the new endpoints and service methods (`service/src/test/java/fi/poltsi/vempain/admin/controller/file/GalleryControllerUTC.java`, `GalleryServiceUTC.java`). [[1]](diffhunk://#diff-8ef76bcfb0d1b3b6b9f5c15aaa8d40963c97d063d1ff6e2c95713f9472ef8676R51-R80) [[2]](diffhunk://#diff-63b30a8ca3df180ce9303d63ddb1be2993127508a56d0e79b331d6f0e3f1c781R434-R465)